### PR TITLE
anime_item type is nullable

### DIFF
--- a/lib/src/model/anime/anime_item.dart
+++ b/lib/src/model/anime/anime_item.dart
@@ -29,7 +29,7 @@ abstract class AnimeItem implements Built<AnimeItem, AnimeItemBuilder> {
   String? get synopsis;
 
   @BuiltValueField(wireName: 'type')
-  String get type;
+  String? get type;
 
   @BuiltValueField(wireName: 'airing_start')
   String? get airingStart;

--- a/lib/src/model/anime/anime_item.g.dart
+++ b/lib/src/model/anime/anime_item.g.dart
@@ -28,8 +28,6 @@ class _$AnimeItemSerializer implements StructuredSerializer<AnimeItem> {
       'image_url',
       serializers.serialize(object.imageUrl,
           specifiedType: const FullType(String)),
-      'type',
-      serializers.serialize(object.type, specifiedType: const FullType(String)),
       'members',
       serializers.serialize(object.members, specifiedType: const FullType(int)),
       'genres',
@@ -53,6 +51,13 @@ class _$AnimeItemSerializer implements StructuredSerializer<AnimeItem> {
     if (value != null) {
       result
         ..add('synopsis')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.type;
+    if (value != null) {
+      result
+        ..add('type')
         ..add(serializers.serialize(value,
             specifiedType: const FullType(String)));
     }
@@ -127,7 +132,7 @@ class _$AnimeItemSerializer implements StructuredSerializer<AnimeItem> {
           break;
         case 'type':
           result.type = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String;
+              specifiedType: const FullType(String)) as String?;
           break;
         case 'airing_start':
           result.airingStart = serializers.deserialize(value,
@@ -198,7 +203,7 @@ class _$AnimeItem extends AnimeItem {
   @override
   final String? synopsis;
   @override
-  final String type;
+  final String? type;
   @override
   final String? airingStart;
   @override
@@ -231,7 +236,7 @@ class _$AnimeItem extends AnimeItem {
       required this.title,
       required this.imageUrl,
       this.synopsis,
-      required this.type,
+      this.type,
       this.airingStart,
       this.episodes,
       required this.members,
@@ -248,7 +253,6 @@ class _$AnimeItem extends AnimeItem {
     BuiltValueNullFieldError.checkNotNull(url, 'AnimeItem', 'url');
     BuiltValueNullFieldError.checkNotNull(title, 'AnimeItem', 'title');
     BuiltValueNullFieldError.checkNotNull(imageUrl, 'AnimeItem', 'imageUrl');
-    BuiltValueNullFieldError.checkNotNull(type, 'AnimeItem', 'type');
     BuiltValueNullFieldError.checkNotNull(members, 'AnimeItem', 'members');
     BuiltValueNullFieldError.checkNotNull(genres, 'AnimeItem', 'genres');
     BuiltValueNullFieldError.checkNotNull(source, 'AnimeItem', 'source');
@@ -480,8 +484,7 @@ class AnimeItemBuilder implements Builder<AnimeItem, AnimeItemBuilder> {
               imageUrl: BuiltValueNullFieldError.checkNotNull(
                   imageUrl, 'AnimeItem', 'imageUrl'),
               synopsis: synopsis,
-              type: BuiltValueNullFieldError.checkNotNull(
-                  type, 'AnimeItem', 'type'),
+              type: type,
               airingStart: airingStart,
               episodes: episodes,
               members: BuiltValueNullFieldError.checkNotNull(


### PR DESCRIPTION
### Description
anime_item **type** is now nullable
### Changes
added nullable to the **type** getter in `anim_item.dart` model file.
### Issue Log
> I[/flutter]() (11676): [https://api.jikan.moe/v3/schedule]()
I[/flutter]() (11676): Deserializing '[request_hash, request:schedule:c955621cf9880cdacea6e012d43654604a1c80f4, req...' to 'Schedule' failed due to: Deserializing '[{mal_id: 48583, url: [https://myanimelist.net/anime/48583/Shingeki_no_Kyojin_]()...' to 'BuiltList<AnimeItem>' failed due to: Deserializing '[mal_id, 48583, url, [https://myanimelist.net/anime/48583/Shingeki_no_Kyojin__]()...' to 'AnimeItem' failed due to: Tried to construct class "AnimeItem" with null field "type". This is forbidden; to allow it, mark "type" with @nullable.
